### PR TITLE
FEATURE: Neos 4.3 compatibility and some tweaks

### DIFF
--- a/Classes/AnchorLinkResolverInterface.php
+++ b/Classes/AnchorLinkResolverInterface.php
@@ -6,26 +6,28 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 
 interface AnchorLinkResolverInterface
 {
-  /**
-   * Return an array of options for the anchor link selectbox:
-   *
-   * [
-   *      [
-   *           'group' => 'first', // optional
-   *           'value' => 'bar',
-   *           'label' => 'Bar',
-   *      ],
-   *      [
-   *           'group' => 'second',
-   *           'value' => 'baz',
-   *           'label' => 'Baz',
-   *      ]
-   * ];
-   *
-   * @param NodeInterface $node Currently focused node
-   * @param string $link Current link value
-   * @param string $searchTerm Search term
-   * @return array
-   */
-  public function resolve(NodeInterface $node, string $link, string $searchTerm);
+    /**
+     * Return an array of options for the anchor link selectbox:
+     *
+     * [
+     *      [
+     *           'icon'  => 'icon-foo', // optional
+     *           'group' => 'first', // optional
+     *           'value' => 'bar',
+     *           'label' => 'Bar',
+     *      ],
+     *      [
+     *           'icon'  => 'icon-foo', // optional
+     *           'group' => 'second',
+     *           'value' => 'baz',
+     *           'label' => 'Baz',
+     *      ]
+     * ];
+     *
+     * @param NodeInterface $node Currently focused node
+     * @param string $link Current link target (for example "node://<some-identifier>" or "https://www.external.url")
+     * @param string $searchTerm Search term (term that has been entered in the "Choose link anchor" search field, defaults to an empty string)
+     * @return array
+     */
+    public function resolve(NodeInterface $node, string $link, string $searchTerm): array;
 }

--- a/Classes/ContentNodeAnchorLinkResolver.php
+++ b/Classes/ContentNodeAnchorLinkResolver.php
@@ -2,6 +2,7 @@
 
 namespace DIU\Neos\AnchorLink;
 
+use Neos\Eel\Exception as EelException;
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Neos\Service\LinkingService;
@@ -11,81 +12,94 @@ use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Neos\Domain\Service\NodeSearchService;
 
 /**
- * Create link anchors based on all content nodes within the target link node
- * Uses node name as an anchor
+ * Create link anchors based on all matching nodes within the target link node
+ *
+ * @see DIU:Neos:AnchorLink:* Settings
  */
 class ContentNodeAnchorLinkResolver implements AnchorLinkResolverInterface
 {
-  /**
-   * @Flow\Inject
-   * @var NodeSearchService
-   */
-  protected $nodeSearchService;
+    /**
+     * @Flow\Inject
+     * @var NodeSearchService
+     */
+    protected $nodeSearchService;
 
-  /**
-   * @Flow\Inject
-   * @var EelEvaluatorInterface
-   */
-  protected $eelEvaluator;
+    /**
+     * @Flow\Inject
+     * @var EelEvaluatorInterface
+     */
+    protected $eelEvaluator;
 
-  /**
-   * @Flow\InjectConfiguration("eelContext")
-   * @var array
-   */
-  protected $contextConfiguration;
+    /**
+     * @Flow\InjectConfiguration("eelContext")
+     * @var array
+     */
+    protected $contextConfiguration;
 
-  /**
-   * @Flow\InjectConfiguration(path="contentNodeType")
-   * @var string
-   */
-  protected $contentNodeType;
+    /**
+     * @Flow\InjectConfiguration(path="contentNodeType")
+     * @var string
+     */
+    protected $contentNodeType;
 
-  /**
-   * @Flow\InjectConfiguration(path="anchor")
-   * @var string
-   */
-  protected $anchor;
+    /**
+     * @Flow\InjectConfiguration(path="anchor")
+     * @var string
+     */
+    protected $anchor;
 
-  /**
-   * @Flow\InjectConfiguration(path="label")
-   * @var string
-   */
-  protected $label;
+    /**
+     * @Flow\InjectConfiguration(path="label")
+     * @var string
+     */
+    protected $label;
 
-  /**
-   * @param NodeInterface $node Currently focused node
-   * @param string $link Current link value
-   * @param string $searchTerm Search term
-   * @return array
-   */
-  public function resolve(NodeInterface $node, string $link, string $searchTerm)
-  {
-    $context = $node->getContext();
-    $targetNode = null;
-    $nodes = [];
+    /**
+     * @Flow\InjectConfiguration(path="group")
+     * @var string
+     */
+    protected $group;
 
-    if (preg_match(LinkingService::PATTERN_SUPPORTED_URIS, $link, $matches) === 1) {
-      if ($matches[1] === 'node') {
-        $targetNode = $context->getNodeByIdentifier($matches[2]) ?? $node;
-      }
+    /**
+     * @Flow\InjectConfiguration(path="icon")
+     * @var string
+     */
+    protected $icon;
+
+    /**
+     * @inheritDoc
+     * @throws EelException
+     */
+    public function resolve(NodeInterface $node, string $link, string $searchTerm): array
+    {
+        $context = $node->getContext();
+        $targetNode = null;
+
+        if ((preg_match(LinkingService::PATTERN_SUPPORTED_URIS, $link, $matches) === 1) && $matches[1] === 'node') {
+            $targetNode = $context->getNodeByIdentifier($matches[2]) ?? $node;
+        }
+        if ($targetNode === null) {
+            return [];
+        }
+
+        if ($searchTerm !== '') {
+            $nodes = $this->nodeSearchService->findByProperties($searchTerm, [$this->contentNodeType], $context, $targetNode);
+        } else {
+            $q = new FlowQuery([$targetNode]);
+            /** @noinspection PhpUndefinedMethodInspection */
+            $nodes = $q->find('[instanceof ' . $this->contentNodeType . ']')->get();
+        }
+        return array_values(array_map(function (NodeInterface $node) {
+            $anchor = (string)Utility::evaluateEelExpression($this->anchor, $this->eelEvaluator, ['node' => $node], $this->contextConfiguration);
+            $label = (string)Utility::evaluateEelExpression($this->label, $this->eelEvaluator, ['node' => $node], $this->contextConfiguration);
+            $group = (string)Utility::evaluateEelExpression($this->group, $this->eelEvaluator, ['node' => $node], $this->contextConfiguration);
+            $icon = (string)Utility::evaluateEelExpression($this->icon, $this->eelEvaluator, ['node' => $node], $this->contextConfiguration);
+            return [
+                'icon' => $icon,
+                'group' => $group,
+                'value' => $anchor,
+                'label' => $label,
+            ];
+        }, $nodes));
     }
-    if (!$targetNode) {
-      return [];
-    }
-
-    if ($searchTerm) {
-      $nodes = $this->nodeSearchService->findByProperties($searchTerm, [$this->contentNodeType], $context, $targetNode);
-    } else {
-      $q = new FlowQuery([$targetNode]);
-      $nodes = $nodes = $q->find('[instanceof ' . $this->contentNodeType . ']')->get();
-    }
-    return array_values(array_map(function ($node) {
-      $anchor = (string) Utility::evaluateEelExpression($this->anchor, $this->eelEvaluator, ['node' => $node], $this->contextConfiguration);
-      $label = (string) Utility::evaluateEelExpression($this->label, $this->eelEvaluator, ['node' => $node], $this->contextConfiguration);
-      return [
-        'value' => $anchor,
-        'label' => $label,
-      ];
-    }, $nodes));
-  }
 }

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -1,4 +1,4 @@
-"DIU.Neos.AnchorLink:AnchorMixin":
+'DIU.Neos.AnchorLink:AnchorMixin':
   abstract: true
   ui:
     inspector:
@@ -15,7 +15,6 @@
           group: anchor
         help:
           message: i18n
-
-Neos.Neos:Content:
-  superTypes:
-    DIU.Neos.AnchorLink:AnchorMixin: true
+      validation:
+        'Neos.Neos/Validation/RegularExpressionValidator':
+          regularExpression: '/^([a-zA-Z\d\-._~\!$&()*+,;=:@%\/?]*)$/'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -8,36 +8,47 @@ Neos:
         autoInclude:
           DIU.Neos.AnchorLink:
             - Main
-            - "NodeTypes/*"
+            - 'NodeTypes/*'
     Ui:
       resources:
         javascript:
-          "DIU.Neos.AnchorLink":
-            resource: '${"resource://DIU.Neos.AnchorLink/Public/JavaScript/AnchorLink/Plugin.js"}'
+          'DIU.Neos.AnchorLink':
+            resource: 'resource://DIU.Neos.AnchorLink/Public/JavaScript/AnchorLink/Plugin.js'
       frontendConfiguration:
-        "Diu.Neos.AnchorLink":
+        'Diu.Neos.AnchorLink':
           displaySearchBox: true
           threshold: 0
   Flow:
     security:
       authentication:
         providers:
-          "Neos.Neos:Backend":
+          'Neos.Neos:Backend':
             requestPatterns:
-              "DIU.Neos.AnchorLink:Backend":
+              'DIU.Neos.AnchorLink:Backend':
                 pattern: ControllerObjectName
                 patternOptions:
                   controllerObjectNamePattern: 'DIU\Neos\AnchorLink\Controller\.*'
     mvc:
       routes:
-        "DIU.Neos.AnchorLink":
-          position: "before Neos.Neos"
+        'DIU.Neos.AnchorLink':
+          position: 'before Neos.Neos'
 DIU:
   Neos:
     AnchorLink:
-      contentNodeType: "DIU.Neos.AnchorLink:AnchorMixin"
+      # The following configuration is only considered if the default ContentNodeAnchorLinkResolver is used:
+
+      # Only nodes of this type will appear in the "Choose link anchor" selector
+      contentNodeType: 'DIU.Neos.AnchorLink:AnchorMixin'
+      # Eel Expression that returns the anchor (without leading "#") for a given node
       anchor: ${node.properties.anchor || node.name}
+      # Eel Expression that returns the label to be rendered in the anchor selector in the Backend
       label: ${node.label}
+      # Eel Expression that returns a group for the anchor selector (empty string == no grouping)
+      group: ${I18n.translate(node.nodeType.label)}
+      # Eel Expression that returns an icon for the anchor selector (empty string = no icon)
+      icon: ${node.nodeType.fullConfiguration.ui.icon}
+
+      # Eel Helpers that are available in the Eel expressions above
       eelContext:
         String: Neos\Eel\Helper\StringHelper
         Array: Neos\Eel\Helper\ArrayHelper
@@ -46,4 +57,3 @@ DIU:
         Math: Neos\Eel\Helper\MathHelper
         Json: Neos\Eel\Helper\JsonHelper
         I18n: Neos\Flow\I18n\EelHelper\TranslationHelper
-        q: Neos\Eel\FlowQuery\FlowQuery::q

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Extends the Neos CKE5 linkeditor with server-side resolvable anchor links.
 3. For all content nodetypes that you would like to be able to link to, inherit from `DIU.Neos.AnchorLink:AnchorMixin`, e.g.:
 
 ```yaml
-Neos.Neos:Content:
+Neos.Neos:Content: # Or other nodetype
   superTypes:
     DIU.Neos.AnchorLink:AnchorMixin: true
 ```
@@ -32,8 +32,12 @@ Neos.Neos:Content:
 4. Adjust the rendering for those nodes to insert anchors before them, e.g. there is included a Fusion processor to help with that:
 
 ```
-prototype(Neos.Neos:Content).@process.anchor = DIU.Neos.AnchorLink:AnchorWrapper
+prototype(Neos.Neos:Content).@process.anchor = DIU.Neos.AnchorLink:AnchorLinkAugmentor
 ```
+
+Note: this will add an `id` attribute to the corresponding output. For this to work reliably the corresponding prototype should render
+a single root element. Otherwise an additional wrapping `div` element will be rendered.
+Also the rendered content must not already contain an `id` attribute because it would be merged with the one from the augmentor in that case.
 
 ## Configuration
 
@@ -45,9 +49,16 @@ These are the defaults:
 DIU:
   Neos:
     AnchorLink:
+      # Only nodes of this type will appear in the "Choose link anchor" selector
       contentNodeType: "DIU.Neos.AnchorLink:AnchorMixin"
+      # Eel Expression that returns the anchor (without leading "#") for a given node
       anchor: ${node.properties.anchor || node.name}
+      # Eel Expression that returns the label to be rendered in the anchor selector in the Backend
       label: ${node.label}
+      # Eel Expression that returns a group for the anchor selector (empty string == no grouping)
+      group: ${I18n.translate(node.nodeType.label)}
+      # Eel Expression that returns an icon for the anchor selector (empty string = no icon)
+      icon: ${node.nodeType.fullConfiguration.ui.icon}
 ```
 
 It's possible to disable the searchbox or adjust its threshold via Settings.yaml, the default settings are:

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -1,8 +1,5 @@
 # Meant to be used as a processor, e.g.:
-# prototype(Neos.Neos:Content).@process.anchor = DIU.Neos.AnchorLink:AnchorWrapper
-prototype(DIU.Neos.AnchorLink:AnchorWrapper) < prototype(Neos.Fusion:Value) {
-    anchor = Neos.Fusion:Tag {
-        attributes.id = ${node.properties.anchor}
-    }
-    value = ${node.properties.anchor ? this.anchor + value : value}
+# prototype(Neos.Neos:Content).@process.anchor = DIU.Neos.AnchorLink:AnchorLinkAugmentor
+prototype(DIU.Neos.AnchorLink:AnchorLinkAugmentor) < prototype(Neos.Fusion:Augmenter) {
+    id = ${Neos.Node.isOfType(node, 'DIU.Neos.AnchorLink:AnchorMixin') && !String.isBlank(q(node).property('anchor')) ? q(node).property('anchor') : node.name}
 }


### PR DESCRIPTION
* Removes `q` from Eel Context for compatibility with Neos < 5.0
* Don't add `AnchorMixin` to all `Content` node types
* Add validation for provided `AnchorMixin.anchor` property
* Allow `icon` and `group` of resolver result to be configurable
  and provide some sane defaults
* Turn `AnchorWrapper` prototype into an Augmentor and rename it to
  `AnchorLinkAugmentor` accordingly
* Some (mostly cosmetic) tweaks