### PR TITLE
Feature: Use only the direct content children

### DIFF
--- a/Classes/ContentNodeAnchorLinkResolver.php
+++ b/Classes/ContentNodeAnchorLinkResolver.php
@@ -83,7 +83,7 @@ class ContentNodeAnchorLinkResolver implements AnchorLinkResolverInterface
         }
 
         if ($searchTerm !== '') {
-            $nodes = $this->nodeSearchService->findByProperties($searchTerm, [$this->contentNodeType], $context, $targetNode);
+            $nodes = $this->nodeSearchService->findByProperties($searchTerm, [$this->contentNodeType], $context, $targetNode->getPrimaryChildNode());
         } else {
             $q = new FlowQuery([$targetNode]);
             /** @noinspection PhpUndefinedMethodInspection */

--- a/Classes/ContentNodeAnchorLinkResolver.php
+++ b/Classes/ContentNodeAnchorLinkResolver.php
@@ -87,7 +87,7 @@ class ContentNodeAnchorLinkResolver implements AnchorLinkResolverInterface
         } else {
             $q = new FlowQuery([$targetNode]);
             /** @noinspection PhpUndefinedMethodInspection */
-            $nodes = $q->find('[instanceof ' . $this->contentNodeType . ']')->get();
+            $nodes = $q->children('[instanceof Neos.Neos:ContentCollection]')->find('[instanceof ' . $this->contentNodeType . ']')->get();
         }
         return array_values(array_map(function (NodeInterface $node) {
             $anchor = (string)Utility::evaluateEelExpression($this->anchor, $this->eelEvaluator, ['node' => $node], $this->contextConfiguration);


### PR DESCRIPTION
resolves #3 

### Description
The Plugin currently displays results from all child nodes of the selected node. This includes all Document Nodes that are in the content tree below it. 

### Steps to Reproduce
1. Add the Anchor as described in the Readme
2. Create a link to root/home in CK Editor 
3. Open the Selection dropdown to select an anchor link

#### Expected behavior
I would expect only content anchors that exist on the 'home' node to be shown

#### Actual behavior
All content anchors from all pages are shown

### Solution
I have added a query to only search through the first child of type contentcollection of the selected Node.  
I am not sure if this is a general enough solution to fit all use cases. 
