### PR TITLE
Bugfix: Check for inactive Dependency

### DIFF
--- a/Classes/ContentNodeAnchorLinkResolver.php
+++ b/Classes/ContentNodeAnchorLinkResolver.php
@@ -5,6 +5,7 @@ namespace DIU\Neos\AnchorLink;
 use Neos\Eel\Exception as EelException;
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 use Neos\Neos\Service\LinkingService;
 use Neos\Eel\EelEvaluatorInterface;
 use Neos\Eel\Utility;
@@ -89,6 +90,11 @@ class ContentNodeAnchorLinkResolver implements AnchorLinkResolverInterface
             /** @noinspection PhpUndefinedMethodInspection */
             $nodes = $q->find('[instanceof ' . $this->contentNodeType . ']')->get();
         }
+
+        if ($this->eelEvaluator instanceof DependencyProxy) {
+            $this->eelEvaluator->_activateDependency();
+        }
+
         return array_values(array_map(function (NodeInterface $node) {
             $anchor = (string)Utility::evaluateEelExpression($this->anchor, $this->eelEvaluator, ['node' => $node], $this->contextConfiguration);
             $label = (string)Utility::evaluateEelExpression($this->label, $this->eelEvaluator, ['node' => $node], $this->contextConfiguration);


### PR DESCRIPTION
closes #24 

This resolves the Error: 

Argument 2 passed to Neos\Eel\Utility_Original::evaluateEelExpression() must implement interface Neos\Eel\EelEvaluatorInterface, instance of Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy given, called in /application/Data/Temporary/Production/SubContextBeach/SubContextBeach/Cache/Code/Flow_Object_Classes/DIU_Neos_AnchorLink_ContentNodeAnchorLinkResolver.php on line 93